### PR TITLE
Update contact headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ Don't forget to update duplicate email addresses in `LendEngine_01_Contacts_[tim
 
 The CSVs from the above scripts (`LendEngine*.csv` for items & contacts) can be imported via Lend Engine's CSV import admin.
 
+- Import contacts (Admin » Settings » Import contacts)
+	- Copy the contents of `LendEngine_01_Contacts_[timestamp].csv` **OR** `LendEngine_01_Contacts_[timestamp]_obfuscated_[timestamp].csv`.
 - Import items (Admin » Items » Bulk update)
 	- Copy the contents of `LendEngine_02_Items_[timestamp].csv` **OR** `LendEngine_02_ItemsAlternative_[timestamp].csv`.
 	- Copy quotes along (copy raw content using text editor, not the selection when opening in a spreadsheet program) to support newlines.
 	- Enable "Create new items where code is not found".
-- Import contacts (Admin » Settings » Import contacts)
-	- Copy the contents of `LendEngine_01_Contacts_[timestamp].csv` **OR** `LendEngine_01_Contacts_[timestamp]_obfuscated_[timestamp].csv`.
 
 ### 4. Import SQLs via Lend Engine support
 

--- a/src/command/ConvertContactsCommand.php
+++ b/src/command/ConvertContactsCommand.php
@@ -45,12 +45,12 @@ class ConvertContactsCommand extends Command
 			'vrw_achternaam'     => 'Last name',
 			'vrw_voornaam'       => 'First name',
 			'vrw_tussenvoegsel'  => 'Last name',
-			'vrw_str_id'         => 'Address line 1',
-			'vrw_huisnr'         => 'Address line 1',
+			'vrw_str_id'         => 'Address',
+			'vrw_huisnr'         => 'Address',
 			'vrw_postcode'       => 'Postcode',
 			'vrw_telefoonnr'     => 'Telephone',
 			'vrw_mobieltelnr'    => 'Telephone',
-			'vrw_email'          => 'Email',
+			'vrw_email'          => 'Email address',
 		];
 		$memberMapping = [
 			'lid_lis_id' => 'is_active',
@@ -133,9 +133,9 @@ class ConvertContactsCommand extends Command
 			$contactConverted = [
 				'First name'        => null,
 				'Last name'         => null,
-				'Email'             => null,
+				'Email address'     => null,
 				'Telephone'         => null,
-				'Address line 1'    => null,
+				'Address'           => null,
 				'City'              => null,
 				'State'             => '-',
 				'Postcode'          => null,
@@ -169,15 +169,15 @@ class ConvertContactsCommand extends Command
 			$contactConverted['Last name'] = trim(implode(' ', $contactConverted['Last name']));
 			
 			// collecting address info
-			$streetId = $contactConverted['Address line 1'][0];
-			$houseNumber = $contactConverted['Address line 1'][1];
+			$streetId = $contactConverted['Address'][0];
+			$houseNumber = $contactConverted['Address'][1];
 			
 			if (isset($streetMapping[$streetId])) {
-				$contactConverted['Address line 1'] = $streetMapping[$streetId]['streetName'].' '.$houseNumber;
+				$contactConverted['Address'] = $streetMapping[$streetId]['streetName'].' '.$houseNumber;
 				$contactConverted['City'] = $streetMapping[$streetId]['placeName'];
 			}
 			else {
-				$contactConverted['Address line 1'] = '[straat id '.$streetId.']'.' '.$houseNumber;
+				$contactConverted['Address'] = '[straat id '.$streetId.']'.' '.$houseNumber;
 			}
 			
 			// phone number

--- a/src/command/ConvertContactsCommand.php
+++ b/src/command/ConvertContactsCommand.php
@@ -22,6 +22,10 @@ class ConvertContactsCommand extends Command
 	private const MEMBER_STATUS_CANCELED = '2';
 	private const MEMBER_STATUS_INACTIVE = '3';
 	
+	// whether or not to allow login after imported in Lend Engine
+	// when false no login link will be added to transactional emails
+	private const ALLOW_LOGIN = true;
+	
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		$service = new ConvertCsvService();
@@ -140,6 +144,7 @@ class ConvertContactsCommand extends Command
 				'State'             => '-',
 				'Postcode'          => null,
 				'Membership number' => null,
+				'Can log in'        => (self::ALLOW_LOGIN === true) ? '1' : '0',
 			];
 			
 			/**

--- a/src/command/ConvertContactsCommand.php
+++ b/src/command/ConvertContactsCommand.php
@@ -211,7 +211,7 @@ class ConvertContactsCommand extends Command
 		file_put_contents($dataDirectory.'/'.$convertedFileName, $convertedCsv);
 		
 		$output->writeln('<info>Done. ' . count($contactsConverted) . ' contacts stored in ' . $convertedFileName . '</info>');
-		$output->writeln('Remember to update duplicate email addresses before importing.');
+		$output->writeln('<comment>Remember to update duplicate email addresses before importing.</comment>');
 		
 		return Command::SUCCESS;
 	}

--- a/src/command/ObfuscateContactsCommand.php
+++ b/src/command/ObfuscateContactsCommand.php
@@ -46,6 +46,7 @@ class ObfuscateContactsCommand extends Command
 			'State',
 			'Postcode',
 			'Membership number',
+			'Can log in',
 		];
 		$contactsCsvLines = $service->getExportCsv($dataDirectory.'/LendEngine_01_Contacts_'.$timestamp.'.csv', $expectedHeaders, $csvSeparator="\t");
 		$output->writeln('Imported ' . count($contactsCsvLines) . ' contacts');

--- a/src/command/ObfuscateContactsCommand.php
+++ b/src/command/ObfuscateContactsCommand.php
@@ -39,9 +39,9 @@ class ObfuscateContactsCommand extends Command
 		$expectedHeaders = [
 			'First name',
 			'Last name',
-			'Email',
+			'Email address',
 			'Telephone',
-			'Address line 1',
+			'Address',
 			'City',
 			'State',
 			'Postcode',
@@ -56,13 +56,13 @@ class ObfuscateContactsCommand extends Command
 		foreach ($contactsCsvLines as $contactCsvLine) {
 			$obfuscatedCsvLine = $contactCsvLine;
 			
-			$obfuscatedCsvLine['First name']        = $obfuscatedCsvLine['First name'] !== '' ?        $faker->firstName()  : '';
-			$obfuscatedCsvLine['Last name']         = $obfuscatedCsvLine['Last name'] !== '' ?         $fakerEN->lastName()  : '';
-			$obfuscatedCsvLine['Telephone']         = $obfuscatedCsvLine['Telephone'] !== '' ?         $faker->phoneNumber()  : '';
-			$obfuscatedCsvLine['Email']             = $obfuscatedCsvLine['Email'] !== '' ?             $faker->safeEmail()  : '';
-			$obfuscatedCsvLine['Address line 1']    = $obfuscatedCsvLine['Address line 1'] !== '' ?    $faker->streetName(). ' '.$faker->randomNumber(4) : '';
-			$obfuscatedCsvLine['City']              = $obfuscatedCsvLine['City'] !== '' ?              $faker->city()  : '';
-			$obfuscatedCsvLine['Postcode']          = $obfuscatedCsvLine['Postcode'] !== '' ?          $faker->postcode()  : '';
+			$obfuscatedCsvLine['First name']    = $obfuscatedCsvLine['First name'] !== '' ?    $faker->firstName()  : '';
+			$obfuscatedCsvLine['Last name']     = $obfuscatedCsvLine['Last name'] !== '' ?     $fakerEN->lastName()  : '';
+			$obfuscatedCsvLine['Telephone']     = $obfuscatedCsvLine['Telephone'] !== '' ?     $faker->phoneNumber()  : '';
+			$obfuscatedCsvLine['Email address'] = $obfuscatedCsvLine['Email address'] !== '' ? $faker->safeEmail()  : '';
+			$obfuscatedCsvLine['Address']       = $obfuscatedCsvLine['Address'] !== '' ?       $faker->streetName(). ' '.$faker->randomNumber(4) : '';
+			$obfuscatedCsvLine['City']          = $obfuscatedCsvLine['City'] !== '' ?          $faker->city()  : '';
+			$obfuscatedCsvLine['Postcode']      = $obfuscatedCsvLine['Postcode'] !== '' ?      $faker->postcode()  : '';
 			
 			// Lend Engine has a limit of 25 chars ...
 			if (mb_strlen($obfuscatedCsvLine['Last name']) > 25) {


### PR DESCRIPTION
Een paar kleine aanpassingen aan de contact migratie. Dit komt omdat de CSV kolomnamen in Lend Engine waren aangepast.

Ik ga ook een PR doen voor Lend Engine om de oude kolomnamen te blijven accepteren. Maar tot die tijd heb je deze PR nodig om een goede export te maken. En daarna is het ook fijn omdat dit de nieuwe kolomnamen zijn.

Ook worden nieuwe contacten nu standaard met inlog-toegestaan geïmporteerd. Als je dat niet wil, kun je `ConvertContactsCommand::ALLOW_LOGIN` aanpassen naar `false`.

cc @Sthroos 