### PR TITLE
optionally add colors to part descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This discusses migrating data and making the correct settings.
 	- ArtikelUitleenDuur
 	- Kasboek
 	- KasboekType
+	- Kleur
 	- Lid
 	- LidStatus
 	- LidType
@@ -69,7 +70,7 @@ Each script migrates a part of the data, you can choose which to run and do a ma
 | Contacts | `convert-contacts` | Contact basics: name, email, phone, address, membership number, etc. |
 | Items | `convert-items` | Item basics: name, code, category, brand, price, etc. |
 | Items alternative | `convert-website-csvs [csvTimestamp]` | Item basics, alternative method with webcatalogus CSVs. |
-| Parts | `gather-extra-data-item-parts` | Count, description. |
+| Parts | `gather-extra-data-item-parts (--useColors)` | Count, description. |
 | Parts mutations | `gather-extra-data-item-part-mutations` | Count missing/broken, explanation. |
 | Images | `gather-extra-data-item-images photos` | Item images (SQL and converted image files). |
 | Memberships | `gather-extra-data-memberships` | Contact <> Subscription, period. |

--- a/src/specification/ColorSpecification.php
+++ b/src/specification/ColorSpecification.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lode\AccessSyncLendEngine\specification;
+
+class ColorSpecification {
+	/**
+	 * @return string[]
+	 */
+	public function getExpectedHeaders(): array
+	{
+		return [
+			'kle_id',
+			'kle_oms',
+			'kle_actief',
+		];
+	}
+}


### PR DESCRIPTION
Dit voegt toe dat je kleur van onderdelen meeneemt in de migratie, zie #19.

Exporteer `Kleur.csv` uit Access en draai `./script/console ./script/command gather-extra-data-item-parts --useColors` om dit te gebruiken.

cc @Sthroos 