### PR TITLE
Strippenkaart heeft (verplichte) lengte nodig

### DIFF
--- a/src/command/GatherExtraDataMembershipsCommand.php
+++ b/src/command/GatherExtraDataMembershipsCommand.php
@@ -33,6 +33,7 @@ class GatherExtraDataMembershipsCommand extends Command
 	private const TARIFF_UNITS = [
 		'Maand' => 30.416666667,
 		'Jaar' => 365,
+		'Keer' => 9999,
 	];
 	
 	protected function execute(InputInterface $input, OutputInterface $output): int
@@ -181,10 +182,7 @@ class GatherExtraDataMembershipsCommand extends Command
 				$category = $tariff['category'];
 			}
 			
-			$duration = 0;
-			if ($category === self::CATEGORY_MEMBERSHIP) {
-				$duration = round($tariff['count'] * self::TARIFF_UNITS[$tariff['unit']]);
-			}
+			$duration = round($tariff['count'] * self::TARIFF_UNITS[$tariff['unit']]);
 			
 			$output->write('Membership type: "'.$name.'" ('.$tariff['category'].'), mapped to '.$category);
 			$output->writeln(', '.$tariff['count'].'x'.$tariff['unit']);


### PR DESCRIPTION
Dit verhelpt de strippenkaart-lidmaatschappen van #8.

@Sthroos zou je kunnen testen of dit een beter resultaat geeft met `./script/console ./script/command gather-extra-data-memberships`? Zonder foutmeldingen tijdens het draaien in ieder geval.

Als je wil kan ik ook wel testen, maar dan moet je nog een keer deze tabellen opsturen:
- KasboekType.csv
- Lid.csv
- LidType.csv
- Tarief.csv
- TariefEenheid.csv
- TariefPeriode.csv
